### PR TITLE
Decode normal maps on export instead of trying to access pixels.

### DIFF
--- a/DecodeNormalMap.shader
+++ b/DecodeNormalMap.shader
@@ -1,0 +1,55 @@
+﻿// @author Felix Herbst, herbst@prefrontalcortex.de, 2018
+
+Shader "Hidden/DecodeNormalMap"
+{
+	Properties
+	{
+		_MainTex ("Texture", 2D) = "white" {}
+	}
+	SubShader
+	{
+		Tags { "RenderType"="Opaque" }
+		LOD 100
+
+		Pass
+		{
+			CGPROGRAM
+			#pragma vertex vert
+			#pragma fragment frag
+			
+			#include "UnityCG.cginc"
+
+			struct appdata
+			{
+				float4 vertex : POSITION;
+				float2 uv : TEXCOORD0;
+			};
+
+			struct v2f
+			{
+				float2 uv : TEXCOORD0;
+				float4 vertex : SV_POSITION;
+			};
+
+			sampler2D _MainTex;
+			float4 _MainTex_ST;
+			
+			v2f vert (appdata v)
+			{
+				v2f o;
+				o.vertex = UnityObjectToClipPos(v.vertex);
+				o.uv = TRANSFORM_TEX(v.uv, _MainTex);
+				return o;
+			}
+			
+			float4 frag (v2f i) : SV_Target
+			{
+				float3 col = UnpackNormal (tex2D (_MainTex, i.uv));
+				col.rg = col.rg / 2 + 0.5;
+				col.b = col.b;
+				return float4(GammaToLinearSpace(col.rgb), 1);
+			}
+			ENDCG
+		}
+	}
+}


### PR DESCRIPTION
Reading raw texture pixels from disk is, in general, not a good idea given the wealth of texture formats Unity supports internally. A Texture2D could come from anywhere - 

- embedded in an FBX file
- PSD file
- RenderTexture
- stored as .asset file on disk
- procedurally generated, only living in memory

One case where that is a problem in the sketchfab exporter is NormalMap exporting - their pixels would only be correct if the normal on disk is already in tangent space (sometimes, but rather rarely the case).

A solution (for the normal maps, but a similar approach would work in general) is to decode the actual texture and convert the necessary data to a PNG or JPEG file which is then stored for glTF usage.
A shader is used to convert into the right encoded normals format (tangent space).

This works for all normal maps, no matter how they were created (greyscale/bumpmap/RenderTex)...